### PR TITLE
feat: add dot-style grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **New Grid Style:** Added a new dot style grid for a minimal look.
+
 ## v1.0.0 - 13 April 2026
 
 ### Added

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,27 +39,38 @@ class Grid {
         break;
 
       case GridType::Dots:
-        float dotSize = 2.0f;
+        float dotRadius = 1.0f;
         vertices.setPrimitiveType(sf::PrimitiveType::Triangles);
         vertices.clear();
 
         for (auto x = 0.0f; x <= windowSize.x; x += CELL_SIZE) {
           for (auto y = 0.0f; y <= windowSize.y; y += CELL_SIZE) {
-            sf::Vector2f offset{x - dotSize / 2.0f, y - dotSize / 2.0f};
+            sf::Color fadedColor{color};
+            fadedColor.a = 0u;
 
-            vertices.append(
-                sf::Vertex{sf::Vector2f{offset.x, offset.y}, color});
-            vertices.append(
-                sf::Vertex{sf::Vector2f{offset.x + dotSize, offset.y}, color});
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
             vertices.append(sf::Vertex{
-                sf::Vector2f{offset.x + dotSize, offset.y + dotSize}, color});
+                sf::Vector2f{x - dotRadius, y - dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y - dotRadius}, fadedColor});
 
-            vertices.append(
-                sf::Vertex{sf::Vector2f{offset.x, offset.y}, color});
-            vertices.append(
-                sf::Vertex{sf::Vector2f{offset.x, offset.y + dotSize}, color});
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
             vertices.append(sf::Vertex{
-                sf::Vector2f{offset.x + dotSize, offset.y + dotSize}, color});
+                sf::Vector2f{x + dotRadius, y - dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y + dotRadius}, fadedColor});
+
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y + dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y + dotRadius}, fadedColor});
+
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y + dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y - dotRadius}, fadedColor});
           }
         }
         break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+enum class GridType : uint8_t { Lines, Dots };
+
 class Grid {
  private:
   sf::VertexArray vertices;
@@ -17,20 +19,50 @@ class Grid {
                         std::round(pos.y / CELL_SIZE) * CELL_SIZE};
   }
 
-  Grid(sf::Vector2f windowSize) {
-    vertices.setPrimitiveType(sf::PrimitiveType::Lines);
-    vertices.clear();
+  sf::Color color{36u, 36u, 36u};
 
-    sf::Color gridColor{36u, 36u, 36u};
+  Grid(sf::Vector2f windowSize, GridType type) {
+    switch (type) {
+      case GridType::Lines:
+        vertices.setPrimitiveType(sf::PrimitiveType::Lines);
+        vertices.clear();
 
-    for (auto x = 0.0f; x < windowSize.x; x += CELL_SIZE) {
-      vertices.append(sf::Vertex{sf::Vector2f{x, 0.0f}, gridColor});
-      vertices.append(sf::Vertex{sf::Vector2f{x, windowSize.y}, gridColor});
-    }
+        for (auto x = 0.0f; x < windowSize.x; x += CELL_SIZE) {
+          vertices.append(sf::Vertex{sf::Vector2f{x, 0.0f}, color});
+          vertices.append(sf::Vertex{sf::Vector2f{x, windowSize.y}, color});
+        }
 
-    for (auto y = 0.0f; y < windowSize.y; y += CELL_SIZE) {
-      vertices.append(sf::Vertex{sf::Vector2f{0.0f, y}, gridColor});
-      vertices.append(sf::Vertex{sf::Vector2f{windowSize.x, y}, gridColor});
+        for (auto y = 0.0f; y < windowSize.y; y += CELL_SIZE) {
+          vertices.append(sf::Vertex{sf::Vector2f{0.0f, y}, color});
+          vertices.append(sf::Vertex{sf::Vector2f{windowSize.x, y}, color});
+        }
+        break;
+
+      case GridType::Dots:
+        float dotSize = 2.0f;
+        vertices.setPrimitiveType(sf::PrimitiveType::Triangles);
+        vertices.clear();
+
+        for (auto x = 0.0f; x <= windowSize.x; x += CELL_SIZE) {
+          for (auto y = 0.0f; y <= windowSize.y; y += CELL_SIZE) {
+            sf::Vector2f offset{x - dotSize / 2.0f, y - dotSize / 2.0f};
+
+            vertices.append(
+                sf::Vertex{sf::Vector2f{offset.x, offset.y}, color});
+            vertices.append(
+                sf::Vertex{sf::Vector2f{offset.x + dotSize, offset.y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{offset.x + dotSize, offset.y + dotSize}, color});
+
+            vertices.append(
+                sf::Vertex{sf::Vector2f{offset.x, offset.y}, color});
+            vertices.append(
+                sf::Vertex{sf::Vector2f{offset.x, offset.y + dotSize}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{offset.x + dotSize, offset.y + dotSize}, color});
+          }
+        }
+        break;
     }
   }
 
@@ -335,7 +367,7 @@ class Simulation {
 
   Simulation(sf::Vector2u windowSize)
       : window{sf::VideoMode(windowSize), "Logic Gates Simulation"},
-        grid{static_cast<sf::Vector2f>(windowSize)} {
+        grid{static_cast<sf::Vector2f>(windowSize), GridType::Dots} {
     window.setFramerateLimit(30u);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ class Grid {
         break;
 
       case GridType::Dots:
-        float dotRadius = 1.0f;
+        float dotRadius = 1.5f;
         vertices.setPrimitiveType(sf::PrimitiveType::Triangles);
         vertices.clear();
 


### PR DESCRIPTION
Adds a dot grid style using 4 triangle diamond pattern with vertex alpha fading.

**Technical Changes:**
- Added `GridTypes` enum to switch between the line and dot grids. 
- Updated Grid to use sf::Triangles.
- Implement a radius alpha gradient from 255 at the center to 0 at the edges.

**Screenshot:**
<img width="782" height="422" alt="image" src="https://github.com/user-attachments/assets/1af854d7-f55a-42a9-9fd4-987fc0d9198f" />