### PR TITLE
feat: add gate removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **New Grid Style:** Added a new dot style grid for a minimal look.
 - **Wire Removal:** Added a way to remove wires by redrag the connection.
+- **Gate Removal:** Added a way to remove gates by pciking up a gate and pressing the `Delete` key
 
 ### Fixed
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,8 @@ class Wire {
   Wire(Pin* startingPin, Pin* endingPin)
       : startPin{startingPin}, endPin{endingPin} {}
 
+  ~Wire() { endPin->state = false; }
+
   void update() {
     if (startPin == nullptr || endPin == nullptr) return;
 
@@ -384,6 +386,12 @@ class GatesManager {
     gates.push_back(std::move(gate));
   }
 
+  void remove(Gate* gate) {
+    std::erase_if(gates, [&gate](const std::unique_ptr<Gate>& g) {
+      return g.get() == gate;
+    });
+  }
+
   Gate* getGateAt(sf::Vector2f pos) {
     for (const auto& g : gates)
       if (g->body.getGlobalBounds().contains(pos)) return g.get();
@@ -476,6 +484,27 @@ class Simulation {
     }
 
     selectedGate->body.setPosition(mousePos - dragOffset);
+  }
+
+  void handleGateRemoval() {
+    if (selectedGate == nullptr) return;
+
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Delete)) {
+      std::erase_if(wiresManager.wires, [this](const std::unique_ptr<Wire>& w) {
+        return std::any_of(selectedGate->inputPins.begin(),
+                           selectedGate->inputPins.end(),
+                           [&w](const Pin& p) {
+                             return w->startPin == &p || w->endPin == &p;
+                           }) ||
+               std::any_of(selectedGate->outputPins.begin(),
+                           selectedGate->outputPins.end(), [&w](const Pin& p) {
+                             return w->startPin == &p || w->endPin == &p;
+                           });
+      });
+
+      gatesManager.remove(selectedGate);
+      selectedGate = nullptr;
+    }
   }
 
   void handleWireDragging() {
@@ -599,6 +628,7 @@ class Simulation {
 
   void update() {
     handleGateMove();
+    handleGateRemoval();
     handleWireDragging();
     wiresManager.update();
     gatesManager.update();


### PR DESCRIPTION
Added the ability to delete gates by picking it up and then press the `Delete` key on the keyboard.

**Technical Changes:**
- Added `handleGateRemoval()` function to the `Simulation` class.
- Added a destructor to `Wire` to manage the setting of the state of the end pin to `false`.
- Added `removeGate()` function to `GatesManager` class.

**Demonstration:**

<img width="782" height="422" alt="delete_gate" src="https://github.com/user-attachments/assets/d71735b1-fa70-4009-a2ac-96f0e80f44a9" />
