### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **New Grid Style:** Added a new dot style grid for a minimal look.
 - **Wire Removal:** Added a way to remove wires by redrag the connection.
+- **Gate Removal:** Added a way to remove gates by pciking up a gate and pressing the `Delete` key
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - **New Grid Style:** Added a new dot style grid for a minimal look.
-
+- **Wire Removal:** Added a way to remove wires by redrag the connection.
 ## v1.0.0 - 13 April 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **New Grid Style:** Added a new dot style grid for a minimal look.
 - **Wire Removal:** Added a way to remove wires by redrag the connection.
 
+### Fixed
+
+- **Reverse Connection:** Fixed an a issue related to unexpected behaviour in gates when creating or deleting wires in reverse order.
+
 ## v1.0.0 - 13 April 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **New Grid Style:** Added a new dot style grid for a minimal look.
+
 ## v1.0.0 - 13 April 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.1.0 19 April 2026
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - **Reverse Connection:** Fixed an a issue related to unexpected behaviour in gates when creating or deleting wires in reverse order.
+- **Better Snapping:** Fixed the snapping of the gates when creating them.
 
 ## v1.0.0 - 13 April 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## Unreleased
+
+### Added
+
 - **New Grid Style:** Added a new dot style grid for a minimal look.
 - **Wire Removal:** Added a way to remove wires by redrag the connection.
+
 ## v1.0.0 - 13 April 2026
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.0)
-project(LogicGateSimulator VERSION 1.0.0 LANGUAGES CXX)
+project(LogicGateSimulator VERSION 1.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,11 +97,15 @@ class Pin {
   }
 };
 
+// TODO: Make vertices and calculateRouting private during refactor
+
 class Wire {
  public:
   Pin* startPin{nullptr};
   Pin* endPin{nullptr};
   sf::VertexArray vertices{sf::PrimitiveType::LineStrip, 4};
+
+  bool showDeleteIndicator{false};
 
   static void calcuateRouting(sf::VertexArray& routingVertices,
                               sf::Vector2f startPos, sf::Vector2f endPos) {
@@ -128,7 +132,8 @@ class Wire {
                       endPin->body.getPosition());
 
       for (size_t i = 0; i < vertices.getVertexCount(); i++)
-        vertices[i].color = sf::Color::Yellow;
+        vertices[i].color =
+            showDeleteIndicator ? sf::Color::Red : sf::Color::Yellow;
 
       window.draw(vertices);
     }
@@ -295,21 +300,47 @@ class WiresManager {
  public:
   std::vector<std::unique_ptr<Wire>> wires;
 
-  bool connectionExists(Pin* startPin, Pin* endPin) const {
-    return std::any_of(
-        wires.begin(), wires.end(), [&startPin, &endPin](const auto& w) {
-          return ((w->startPin == startPin && w->endPin == endPin) ||
-                  (w->startPin == endPin && w->endPin == startPin));
-        });
+  static bool canConnect(Pin* startPin, Pin* endPin) {
+    return startPin != endPin && startPin->type != endPin->type;
   }
 
-  bool canConnect(Pin* startPin, Pin* endPin) const {
-    return startPin != endPin && startPin->type != endPin->type;
+  bool connectionExists(Pin* startPin, Pin* endPin) const {
+    return std::any_of(wires.begin(), wires.end(),
+                       [&startPin, &endPin](const std::unique_ptr<Wire>& w) {
+                         return isSameConnection(w.get(), startPin, endPin);
+                       });
   }
 
   void createWire(Pin* startPin, Pin* endPin) {
     auto wire = std::make_unique<Wire>(startPin, endPin);
     wires.push_back(std::move(wire));
+  }
+
+  void deleteWire(Pin* startPin, Pin* endPin) {
+    auto w = std::find_if(
+        wires.begin(), wires.end(),
+        [&startPin, &endPin, this](const std::unique_ptr<Wire>& w) {
+          return isSameConnection(w.get(), startPin, endPin);
+        });
+
+    if (w != wires.end()) {
+      endPin->state = false;
+      wires.erase(w);
+    }
+  }
+
+  Wire* getWire(Pin* startPin, Pin* endPin) {
+    auto w = std::find_if(
+        wires.begin(), wires.end(),
+        [&startPin, &endPin, this](const std::unique_ptr<Wire>& w) {
+          return isSameConnection(w.get(), startPin, endPin);
+        });
+
+    if (w != wires.end()) {
+      return w->get();
+    }
+
+    return nullptr;
   }
 
   void update() {
@@ -318,6 +349,13 @@ class WiresManager {
 
   void render(sf::RenderWindow& window) {
     for (auto& w : wires) w->render(window);
+  }
+
+ private:
+  static bool isSameConnection(const Wire* w, const Pin* startPin,
+                               const Pin* endPin) {
+    return ((w->startPin == startPin && w->endPin == endPin) ||
+            (w->startPin == endPin && w->endPin == startPin));
   }
 };
 
@@ -360,6 +398,7 @@ class GatesManager {
   }
 };
 
+// TODO: Refactor access specifiers
 class Simulation {
  public:
   GatesManager gatesManager;
@@ -375,6 +414,7 @@ class Simulation {
 
   Pin* selectedPin{nullptr};
   sf::VertexArray previewWireVertices{sf::PrimitiveType::LineStrip, 4};
+  Wire* wireToDelete{nullptr};
 
   Simulation(sf::Vector2u windowSize)
       : window{sf::VideoMode(windowSize), "Logic Gates Simulation"},
@@ -425,18 +465,49 @@ class Simulation {
   }
 
   void handleWireDragging() {
+    sf::Color previewWireColor = sf::Color::Green;
     lmbPressed = sf::Mouse::isButtonPressed(sf::Mouse::Button::Left);
     sf::Vector2f mousePos =
         window.mapPixelToCoords(sf::Mouse::getPosition(window));
+
+    if (wireToDelete != nullptr) {
+      wireToDelete->showDeleteIndicator = false;
+      wireToDelete = nullptr;
+    }
+
+    auto endPin = gatesManager.getPinAt(mousePos);
+    if (lmbPressed && selectedPin != nullptr && endPin != nullptr) {
+      if (endPin == selectedPin)
+        endPin = nullptr;
+      else {
+        wireToDelete = wiresManager.getWire(selectedPin, endPin);
+        if (wireToDelete != nullptr) {
+          auto wireIt =
+              std::find_if(wiresManager.wires.begin(), wiresManager.wires.end(),
+                           [this](const std::unique_ptr<Wire>& w) {
+                             return wireToDelete == w.get();
+                           });
+
+          if (wireIt != wiresManager.wires.end()) {
+            std::rotate(wiresManager.wires.begin(), wireIt, wireIt + 1);
+
+            wireToDelete->showDeleteIndicator = true;
+            previewWireColor = sf::Color::Transparent;
+          }
+        }
+      }
+    }
 
     if (!lmbPressed) {
       if (selectedPin == nullptr) return;
 
       // Just released a pin
-      auto endPin = gatesManager.getPinAt(mousePos);
-      if (endPin != nullptr && wiresManager.canConnect(selectedPin, endPin) &&
-          !wiresManager.connectionExists(selectedPin, endPin))
-        wiresManager.createWire(selectedPin, endPin);
+      if (endPin != nullptr && WiresManager::canConnect(selectedPin, endPin)) {
+        if (wiresManager.connectionExists(selectedPin, endPin))
+          wiresManager.deleteWire(selectedPin, endPin);
+        else
+          wiresManager.createWire(selectedPin, endPin);
+      }
 
       selectedPin = nullptr;
 
@@ -455,7 +526,7 @@ class Simulation {
                           mousePos);
 
     for (size_t i = 0; i < previewWireVertices.getVertexCount(); i++)
-      previewWireVertices[i].color = sf::Color::Yellow;
+      previewWireVertices[i].color = previewWireColor;
   }
 
   void handleEvents() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+enum class GridType : uint8_t { Lines, Dots };
+
 class Grid {
  private:
   sf::VertexArray vertices;
@@ -17,20 +19,61 @@ class Grid {
                         std::round(pos.y / CELL_SIZE) * CELL_SIZE};
   }
 
-  Grid(sf::Vector2f windowSize) {
-    vertices.setPrimitiveType(sf::PrimitiveType::Lines);
-    vertices.clear();
+  sf::Color color{36u, 36u, 36u};
 
-    sf::Color gridColor{36u, 36u, 36u};
+  Grid(sf::Vector2f windowSize, GridType type) {
+    switch (type) {
+      case GridType::Lines:
+        vertices.setPrimitiveType(sf::PrimitiveType::Lines);
+        vertices.clear();
 
-    for (auto x = 0.0f; x < windowSize.x; x += CELL_SIZE) {
-      vertices.append(sf::Vertex{sf::Vector2f{x, 0.0f}, gridColor});
-      vertices.append(sf::Vertex{sf::Vector2f{x, windowSize.y}, gridColor});
-    }
+        for (auto x = 0.0f; x < windowSize.x; x += CELL_SIZE) {
+          vertices.append(sf::Vertex{sf::Vector2f{x, 0.0f}, color});
+          vertices.append(sf::Vertex{sf::Vector2f{x, windowSize.y}, color});
+        }
 
-    for (auto y = 0.0f; y < windowSize.y; y += CELL_SIZE) {
-      vertices.append(sf::Vertex{sf::Vector2f{0.0f, y}, gridColor});
-      vertices.append(sf::Vertex{sf::Vector2f{windowSize.x, y}, gridColor});
+        for (auto y = 0.0f; y < windowSize.y; y += CELL_SIZE) {
+          vertices.append(sf::Vertex{sf::Vector2f{0.0f, y}, color});
+          vertices.append(sf::Vertex{sf::Vector2f{windowSize.x, y}, color});
+        }
+        break;
+
+      case GridType::Dots:
+        float dotRadius = 1.5f;
+        vertices.setPrimitiveType(sf::PrimitiveType::Triangles);
+        vertices.clear();
+
+        for (auto x = 0.0f; x <= windowSize.x; x += CELL_SIZE) {
+          for (auto y = 0.0f; y <= windowSize.y; y += CELL_SIZE) {
+            sf::Color fadedColor{color};
+            fadedColor.a = 0u;
+
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y - dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y - dotRadius}, fadedColor});
+
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y - dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y + dotRadius}, fadedColor});
+
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x + dotRadius, y + dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y + dotRadius}, fadedColor});
+
+            vertices.append(sf::Vertex{sf::Vector2f{x, y}, color});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y + dotRadius}, fadedColor});
+            vertices.append(sf::Vertex{
+                sf::Vector2f{x - dotRadius, y - dotRadius}, fadedColor});
+          }
+        }
+        break;
     }
   }
 
@@ -335,7 +378,7 @@ class Simulation {
 
   Simulation(sf::Vector2u windowSize)
       : window{sf::VideoMode(windowSize), "Logic Gates Simulation"},
-        grid{static_cast<sf::Vector2f>(windowSize)} {
+        grid{static_cast<sf::Vector2f>(windowSize), GridType::Dots} {
     window.setFramerateLimit(30u);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,7 +382,8 @@ class GatesManager {
   template <std::derived_from<Gate> G>
   void create(sf::Vector2f position) {
     auto gate = std::make_unique<G>();
-    gate->body.setPosition(Grid::snapPoint(position));
+    gate->body.setPosition(
+        Grid::snapPoint(position - gate->body.getGeometricCenter()));
     gates.push_back(std::move(gate));
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,8 @@ class Wire {
   Wire(Pin* startingPin, Pin* endingPin)
       : startPin{startingPin}, endPin{endingPin} {}
 
+  ~Wire() { endPin->state = false; }
+
   void update() {
     if (startPin == nullptr || endPin == nullptr) return;
 
@@ -384,6 +386,12 @@ class GatesManager {
     gates.push_back(std::move(gate));
   }
 
+  void remove(Gate* gate) {
+    std::erase_if(gates, [&gate](const std::unique_ptr<Gate>& g) {
+      return g.get() == gate;
+    });
+  }
+
   Gate* getGateAt(sf::Vector2f pos) {
     for (const auto& g : gates)
       if (g->body.getGlobalBounds().contains(pos)) return g.get();
@@ -476,6 +484,27 @@ class Simulation {
     }
 
     selectedGate->body.setPosition(mousePos - dragOffset);
+  }
+
+  void handleGateRemoval() {
+    if (selectedGate == nullptr) return;
+
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Delete)) {
+      std::erase_if(wiresManager.wires, [this](const std::unique_ptr<Wire>& w) {
+        return std::any_of(selectedGate->inputPins.begin(),
+                           selectedGate->inputPins.end(),
+                           [&w](const Pin& p) {
+                             return w->startPin == &p || w->endPin == &p;
+                           }) ||
+               std::any_of(selectedGate->outputPins.begin(),
+                           selectedGate->outputPins.end(), [&w](const Pin& p) {
+                             return w->startPin == &p || w->endPin == &p;
+                           });
+      });
+
+      gatesManager.remove(selectedGate);
+      selectedGate = nullptr;
+    }
   }
 
   void handleWireDragging() {
@@ -599,6 +628,7 @@ class Simulation {
 
   void update() {
     handleGateMove();
+    handleGateRemoval();
     handleWireDragging();
     wiresManager.update();
     gatesManager.update();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,7 +311,17 @@ class WiresManager {
                        });
   }
 
-  void createWire(Pin* startPin, Pin* endPin) {
+  void createWire(Pin* pin1, Pin* pin2) {
+    Pin* startPin;
+    Pin* endPin;
+    if (pin1->type == PinType::Output) {
+      startPin = pin1;
+      endPin = pin2;
+    } else {
+      startPin = pin2;
+      endPin = pin1;
+    }
+
     auto wire = std::make_unique<Wire>(startPin, endPin);
     wires.push_back(std::move(wire));
   }
@@ -324,7 +334,11 @@ class WiresManager {
         });
 
     if (w != wires.end()) {
-      endPin->state = false;
+      if (startPin->type == PinType::Input)
+        startPin->state = false;
+      else
+        endPin->state = false;
+
       wires.erase(w);
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,9 +20,10 @@ class Grid {
   }
 
   sf::Color color{36u, 36u, 36u};
+  GridType style;
 
-  Grid(sf::Vector2f windowSize, GridType type) {
-    switch (type) {
+  void create(sf::Vector2f windowSize) {
+    switch (style) {
       case GridType::Lines:
         vertices.setPrimitiveType(sf::PrimitiveType::Lines);
         vertices.clear();
@@ -440,9 +441,11 @@ class Simulation {
   Wire* wireToDelete{nullptr};
 
   Simulation(sf::Vector2u windowSize)
-      : window{sf::VideoMode(windowSize), "Logic Gates Simulation"},
-        grid{static_cast<sf::Vector2f>(windowSize), GridType::Dots} {
+      : window{sf::VideoMode(windowSize), "Logic Gates Simulation"} {
     window.setFramerateLimit(30u);
+
+    grid.style = GridType::Dots;
+    grid.create(static_cast<sf::Vector2f>(window.getSize()));
   }
 
   void start() {
@@ -621,6 +624,12 @@ class Simulation {
 
           case sf::Keyboard::Scancode::Num8:
             gatesManager.create<XnorGate>(mousePos);
+            break;
+
+          case sf::Keyboard::Scancode::F1:
+            grid.style = grid.style == GridType::Lines ? GridType::Dots
+                                                       : GridType::Lines;
+            grid.create(static_cast<sf::Vector2f>(window.getSize()));
             break;
         }
       }


### PR DESCRIPTION
## Features
### Added

- **New Grid Style:** Added a new dot style grid for a minimal look.
- **Wire Removal:** Added a way to remove wires by redrag the connection.
- **Gate Removal:** Added a way to remove gates by pciking up a gate and pressing the `Delete` key

### Fixed

- **Reverse Connection:** Fixed an a issue related to unexpected behaviour in gates when creating or deleting wires in reverse order.
- **Better Snapping:** Fixed the snapping of the gates when creating them.

## Demonstrations

Dot-style Grid for minimal looks (Press `F1` to switch between the styles)

<img width="782" height="422" alt="image" src="https://github.com/user-attachments/assets/2c6aa89d-ff02-42f8-8a5b-bf44b025f285" />

Pick up a gate and press the `Delete` key to remove.

<img width="782" height="422" alt="delete_gate" src="https://github.com/user-attachments/assets/ad78e487-609f-47d8-8fa0-3869d4e528a6" />

Drag a wire between existing connections to delete the wire.

<img width="782" height="422" alt="wire_removal_demo" src="https://github.com/user-attachments/assets/bf8b7609-97be-4711-9e0d-43b36fee5e16" />




